### PR TITLE
Translation File Creator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ sourceSets {
     api
     main
     test
+    main.resources.srcDirs += 'src/generated/resources'
 }
 
 minecraft {

--- a/src/generated/resources/.cache/cache
+++ b/src/generated/resources/.cache/cache
@@ -1,0 +1,2 @@
+a09de92fff74f6393a89d7326070843c60684fc3 assets/redpandas/lang/es_es.json
+79788c6544066ac437a288c67355d14e398166e2 assets/redpandas/lang/fr_fr.json

--- a/src/generated/resources/assets/redpandas/lang/es_es.json
+++ b/src/generated/resources/assets/redpandas/lang/es_es.json
@@ -1,0 +1,4 @@
+{
+  "entity.redpandas.red_panda": "Panda rojo",
+  "item.redpandas.red_panda_spawn_egg": "Generar panda rojo"
+}

--- a/src/generated/resources/assets/redpandas/lang/fr_fr.json
+++ b/src/generated/resources/assets/redpandas/lang/fr_fr.json
@@ -1,0 +1,4 @@
+{
+  "entity.redpandas.red_panda": "Panda rouge",
+  "item.redpandas.red_panda_spawn_egg": "Oeuf d'apparition de panda rouge"
+}

--- a/src/main/java/cat/tophat/redpandas/RedPandas.java
+++ b/src/main/java/cat/tophat/redpandas/RedPandas.java
@@ -2,6 +2,7 @@ package cat.tophat.redpandas;
 
 import cat.tophat.redpandas.common.PandasConfig;
 import cat.tophat.redpandas.common.entities.RedPandaEntity;
+import cat.tophat.redpandas.data.Translations;
 import net.minecraft.entity.CreatureEntity;
 import net.minecraft.entity.EntityClassification;
 import net.minecraft.entity.EntitySpawnPlacementRegistry;
@@ -18,6 +19,7 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber.Bus;
 import net.minecraftforge.fml.config.ModConfig;
+import net.minecraftforge.fml.event.lifecycle.GatherDataEvent;
 
 import java.awt.Color;
 
@@ -54,5 +56,10 @@ public class RedPandas {
     public static void onItemRegistry(RegistryEvent.Register<Item> event) {
         event.getRegistry().register(new SpawnEggItem(RED_PANDA_ENTITY, Color.RED.getRGB(), Color.BLACK.getRGB(),
                 new Item.Properties().group(ItemGroup.MISC)).setRegistryName(MODID + ":red_panda_spawn_egg"));
+    }
+
+    @SubscribeEvent
+    public static void onGatherData(GatherDataEvent event) {
+        if(event.includeClient()) for(String locale : new String[] {"es_es", "fr_fr"}) event.getGenerator().addProvider(new Translations(event.getGenerator(), locale));
     }
 }

--- a/src/main/java/cat/tophat/redpandas/data/Translations.java
+++ b/src/main/java/cat/tophat/redpandas/data/Translations.java
@@ -1,0 +1,32 @@
+package cat.tophat.redpandas.data;
+
+import cat.tophat.redpandas.RedPandas;
+import net.minecraft.data.DataGenerator;
+import net.minecraftforge.common.data.LanguageProvider;
+
+public class Translations extends LanguageProvider {
+
+    public Translations(DataGenerator gen, String locale) {
+        super(gen, RedPandas.MODID, locale);
+    }
+
+    @Override
+    protected void addTranslations() {
+        String locale = this.getName().replace("Languages: ", "");
+        switch(locale) {
+        case "es_es":
+            addTranslation("Panda rojo", "Generar panda rojo");
+        	break;
+        case "fr_fr":
+            addTranslation("Panda rouge", "Oeuf d'apparition de panda rouge");
+        	break;
+        default:
+            break;
+        }
+    }
+
+    private void addTranslation(String red_panda, String red_panda_spawn_egg) {
+        add(RedPandas.RED_PANDA_ENTITY, red_panda);
+        add("item.redpandas.red_panda_spawn_egg", red_panda_spawn_egg);
+    }
+}


### PR DESCRIPTION
- Add translation helper to allow easier creation to translations. It also supports unicode conversion for non-english characters.
- Add translations for Spanish (Spain) and French (France). Translations are based off of my understanding of the languages and the vanilla implementation of them for pandas.

For the translation file creator, a language just needs to be added to the array and then declared within the switch statement.