### PR TITLE
Configuration + Spawning Registration improvements

### DIFF
--- a/src/main/java/cat/tophat/redpandas/RedPandas.java
+++ b/src/main/java/cat/tophat/redpandas/RedPandas.java
@@ -4,7 +4,7 @@ import cat.tophat.redpandas.common.PandasConfig;
 import cat.tophat.redpandas.common.RedPandaEvents;
 import cat.tophat.redpandas.common.entities.RedPandaEntity;
 import cat.tophat.redpandas.data.Translations;
-import net.minecraft.entity.CreatureEntity;
+import net.minecraft.entity.MobEntity;
 import net.minecraft.entity.EntityClassification;
 import net.minecraft.entity.EntitySpawnPlacementRegistry;
 import net.minecraft.entity.EntityType;
@@ -44,8 +44,10 @@ public class RedPandas {
                     .setTrackingRange(80)
                     .setUpdateInterval(1)
                     .setShouldReceiveVelocityUpdates(true)
-                    .build(RedPandas.MODID + ":red_panda")
-                    .setRegistryName(new ResourceLocation(RedPandas.MODID, "red_panda"));
+                    .build(RedPandas.MODID + ":red_panda");
+    static {
+        RED_PANDA_ENTITY.setRegistryName(new ResourceLocation(RedPandas.MODID, "red_panda"));
+    }
 
     @SubscribeEvent
     public static void registerEntity(RegistryEvent.Register<EntityType<?>> event) {
@@ -53,7 +55,7 @@ public class RedPandas {
 
         EntitySpawnPlacementRegistry.register(RED_PANDA_ENTITY,
                 EntitySpawnPlacementRegistry.PlacementType.ON_GROUND,
-                Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, CreatureEntity::canSpawnOn);
+                Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, MobEntity::canSpawnOn);
     }
 
     @SubscribeEvent

--- a/src/main/java/cat/tophat/redpandas/common/PandasConfig.java
+++ b/src/main/java/cat/tophat/redpandas/common/PandasConfig.java
@@ -19,7 +19,12 @@ public class PandasConfig {
 
     public static class ServerConfig {
         public final ForgeConfigSpec.BooleanValue redPandaSpawnNaturally;
+        public final ForgeConfigSpec.BooleanValue redPandaUseSpawnCost;
         public final ForgeConfigSpec.IntValue redPandaSpawnWeight;
+        public final ForgeConfigSpec.IntValue redPandaSpawnMinGroup;
+        public final ForgeConfigSpec.IntValue redPandaSpawnMaxGroup;
+        public final ForgeConfigSpec.DoubleValue redPandaSpawnCostPer;
+        public final ForgeConfigSpec.DoubleValue redPandaSpawnCostMax;
         public final ForgeConfigSpec.ConfigValue<List<? extends String>> biomeWhitelist;
         public final ForgeConfigSpec.ConfigValue<List<? extends String>> biomeBlacklist;
 
@@ -27,9 +32,23 @@ public class PandasConfig {
             redPandaSpawnNaturally = builder.comment("If Red Pandas should spawn naturally in the world.")
                     .define("enableNaturalSpawning", true);
 
-            redPandaSpawnWeight = builder.comment("If -1, the default spawn weight will be used. "
-                    + "(The higher the value the more will spawn)")
-                    .defineInRange("spawnWeight", 4, -1, Integer.MAX_VALUE);
+            redPandaSpawnWeight = builder.comment("The higher the value the more likely a Red Panda is to spawn (as opposed to spawning another entity in its place)")
+                    .defineInRange("spawnWeight", 7, 0, Integer.MAX_VALUE);
+
+            redPandaSpawnMinGroup = builder.comment("The minimum group size for spawning red pandas.")
+            .defineInRange("spawnMinGroup", 1, 1, Integer.MAX_VALUE);
+
+            redPandaSpawnMaxGroup = builder.comment("The maximum group size for spawning red pandas. Must be greater than or equal to the minimum")
+            .defineInRange("spawnMaxGroup", 5, 1, Integer.MAX_VALUE);
+
+            redPandaUseSpawnCost = builder.comment("If Red Pandas should utilize spawn costs or not.")
+            .define("spawnCostEnabled", false);
+
+            redPandaSpawnCostPer = builder.comment("The spawn cost per red panda spawned.")
+            .defineInRange("spawnCostPer", 1, Double.MIN_NORMAL, Double.MAX_VALUE);
+
+            redPandaSpawnCostMax = builder.comment("The maximum spawn cost that can be spent on red pandas.")
+            .defineInRange("spawnCostMax", 0.2, Double.MIN_NORMAL, Double.MAX_VALUE);
 
             biomeWhitelist = builder.comment("If biomes are specified here,"
                     + " Red Pandas will ONLY spawn in these biomes. (The blacklist is ignored while this is set!)")

--- a/src/main/java/cat/tophat/redpandas/common/RedPandaEvents.java
+++ b/src/main/java/cat/tophat/redpandas/common/RedPandaEvents.java
@@ -1,68 +1,39 @@
 package cat.tophat.redpandas.common;
 
+import java.util.Set;
+import java.util.function.Predicate;
+
+import com.google.common.collect.Sets;
+
 import cat.tophat.redpandas.RedPandas;
 import cat.tophat.redpandas.common.entities.RedPandaEntity;
-import com.google.common.collect.Sets;
 import net.minecraft.entity.EntityClassification;
 import net.minecraft.entity.ai.attributes.GlobalEntityTypeAttributes;
 import net.minecraft.util.ResourceLocation;
-import net.minecraft.util.WeightedRandom;
 import net.minecraft.world.biome.MobSpawnInfo;
-import net.minecraftforge.common.util.NonNullLazy;
+import net.minecraft.world.biome.MobSpawnInfo.Builder;
 import net.minecraftforge.event.world.BiomeLoadingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
-import org.apache.commons.lang3.reflect.FieldUtils;
-
-import java.lang.reflect.Field;
-import java.util.Set;
-import java.util.function.Predicate;
 
 @Mod.EventBusSubscriber(modid = RedPandas.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class RedPandaEvents {
 
-    private static final NonNullLazy<MobSpawnInfo.Spawners> entry = NonNullLazy.of(() -> new MobSpawnInfo.Spawners(RedPandas.RED_PANDA_ENTITY, 4, 1, 5));
-    private static final Field WEIGHT = ObfuscationReflectionHelper.findField(WeightedRandom.Item.class, "field_76292_a"); //itemWeight
-
-    static {
-        FieldUtils.removeFinalModifier(WEIGHT);
-    }
-
     private static Predicate<ResourceLocation> allowBiome = null;
-    private static int currentWeight = 0;
 
     @SubscribeEvent
     public static void onLoad(ModConfig.Loading event) {
-        if (event.getConfig().getSpec() != PandasConfig.SERVER_SPECIFICATION) {
+        if(event.getConfig().getSpec() != PandasConfig.SERVER_SPECIFICATION) {
             return;
         }
-
-        if (PandasConfig.SERVER.redPandaSpawnNaturally.get()) {
-            currentWeight = PandasConfig.SERVER.redPandaSpawnWeight.get();
-
-            if (currentWeight > 0) {
-                if (PandasConfig.SERVER.biomeWhitelist.get() != null
-                        && !PandasConfig.SERVER.biomeWhitelist.get().isEmpty()) {
-                    Set<String> whitelist = Sets.newHashSet(PandasConfig.SERVER.biomeWhitelist.get());
-                    allowBiome = b -> whitelist.contains(b.toString());
-                } else {
-                    if (PandasConfig.SERVER.biomeBlacklist.get() != null
-                            && !PandasConfig.SERVER.biomeBlacklist.get().isEmpty()) {
-                        Set<String> blacklist = Sets.newHashSet(PandasConfig.SERVER.biomeBlacklist.get());
-                        allowBiome = b -> !blacklist.contains(b.toString());
-                    }
-                }
-            }
-        } else {
-            currentWeight = 0;
-        }
-        try {
-            WEIGHT.setInt(entry.get(), currentWeight);
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
+        if(PandasConfig.SERVER.biomeWhitelist.get() != null && !PandasConfig.SERVER.biomeWhitelist.get().isEmpty()) {
+            Set<String> whitelist = Sets.newHashSet(PandasConfig.SERVER.biomeWhitelist.get());
+            allowBiome = b -> whitelist.contains(b.toString());
+        } else if(PandasConfig.SERVER.biomeBlacklist.get() != null && !PandasConfig.SERVER.biomeBlacklist.get().isEmpty()) {
+            Set<String> blacklist = Sets.newHashSet(PandasConfig.SERVER.biomeBlacklist.get());
+            allowBiome = b -> !blacklist.contains(b.toString());
         }
     }
 
@@ -72,10 +43,12 @@ public class RedPandaEvents {
     }
 
     public static void biomeLoad(BiomeLoadingEvent event) {
-        if (currentWeight > 0 && allowBiome.test(event.getName())) {
-            event.getSpawns()
-                    .withSpawner(EntityClassification.CREATURE, entry.get())
-                    .withSpawnCost(RedPandas.RED_PANDA_ENTITY, 1, 0.2);
+        if(PandasConfig.SERVER.redPandaSpawnNaturally.get() && PandasConfig.SERVER.redPandaSpawnWeight.get() > 0 && allowBiome.test(event.getName())) {
+            MobSpawnInfo.Spawners entry = new MobSpawnInfo.Spawners(RedPandas.RED_PANDA_ENTITY, PandasConfig.SERVER.redPandaSpawnWeight.get(), PandasConfig.SERVER.redPandaSpawnMinGroup.get(), PandasConfig.SERVER.redPandaSpawnMaxGroup.get());
+            Builder builder = event.getSpawns().withSpawner(EntityClassification.CREATURE, entry);
+            if(PandasConfig.SERVER.redPandaUseSpawnCost.get()) {
+                builder.withSpawnCost(RedPandas.RED_PANDA_ENTITY, PandasConfig.SERVER.redPandaSpawnCostPer.get(), PandasConfig.SERVER.redPandaSpawnCostMax.get());
+            }
         }
     }
 }


### PR DESCRIPTION
Added configuration fields for:

- Maximum Group
- Minimum Group
- Spawn Cost Per
- Spawn Cost Max
- Use Spawn Cost (Set to false by default, very few entities have spawn costs in vanilla. Also only in select cases)

Cleaned up some warnings in `RedPandas`
Slightly increased default spawn weight, and removed the "-1 default" thing